### PR TITLE
Update task_service_impl.py

### DIFF
--- a/task-service/app/service/task_service_impl.py
+++ b/task-service/app/service/task_service_impl.py
@@ -12,7 +12,7 @@ class TaskServiceImpl(ITaskService):
         return self.db.query(Task).all()
 
     def create_task(self, task_data: TaskCreate) -> Task:
-        task = Task(**task_data.dict())
+        task = Task(**task_data.model_dump())
         self.db.add(task)
         self.db.commit()
         self.db.refresh(task)


### PR DESCRIPTION
Bonus Tip:
If you're migrating from Pydantic v1 to v2, you should:

Replace BaseModel.dict() → BaseModel.model_dump()

Replace BaseModel.json() → BaseModel.model_dump_json()